### PR TITLE
Split Boilerplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.log
 *.retry
+.vagrant/

--- a/tests/boilerplate.yml
+++ b/tests/boilerplate.yml
@@ -1,0 +1,28 @@
+---
+
+- hosts: all
+  become: True
+
+  tasks:
+    - name: Update local apt cache (Ubuntu)
+      apt:
+        update_cache: True
+      when: ansible_os_family == 'Debian'
+
+    - name: Install policycoreutils-python
+      yum:
+        name: 'policycoreutils-python'
+        state: present
+      when: ansible_os_family == 'RedHat'
+
+    # Workaround for selinux errors when using sqlite DB
+    - name: Set permissive SElinux for httpd domain
+      selinux_permissive:
+        name: 'httpd_t'
+        permissive: True
+      when:
+        - ansible_selinux
+        - ansible_virtualization_type != 'docker'
+
+  roles:
+    - openstack-repo

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,4 +1,4 @@
 ---
 
-- name: openstack-repo
-  src: abelboldu.openstack-repo
+- name: 'openstack-repo'
+  src: 'abelboldu.openstack-repo'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,18 +1,11 @@
 ---
 
+- include: boilerplate.yml
+
 - hosts: all
   become: True
 
-  pre_tasks:
-    - name: Update local apt cache
-      apt:
-        update_cache: True
-      when: ansible_distribution == 'Ubuntu'
-
   roles:
-    - role: openstack-repo
-      when: ansible_os_family == 'RedHat'
-
     - role: rabbitmq
       rabbitmq_plugins:
         - 'rabbitmq_management'


### PR DESCRIPTION
Since all roles will have a boilerplate, it will be easier to split the
boilerplate into a dedicated file so that if and when the boilerplate is
updated, it will be just a matter of copying files around.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
