### PR TITLE
Enable Node Param for Rabbit Vhost

### DIFF
--- a/tasks/vhost.yml
+++ b/tasks/vhost.yml
@@ -13,8 +13,7 @@
     user: '{{ item.user }}'
     password: '{{ item.password }}'
     vhost: '{{ item.vhost | default("/") }}'
-    # Disabled due to ansible bug https://github.com/ansible/ansible-modules-extras/pull/2310
-    # node: '{{ item.node | default("rabbit") }}'
+    node: '{{ item.node | default("rabbit") }}'
     tags: '{{ (item.tags | default("")) | join(",") }}'
     configure_priv: '{{ item.configure_priv | default(".*") }}'
     read_priv: '{{ item.read_priv | default(".*") }}'


### PR DESCRIPTION
`node` parameter for `rabbitmq_user` module was temporarily disabled due
to a bug in `rabbitmq_user`.  Since `rabbitmq_user` is fixed in the
upstream package, re-enabling it.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
