### PR TITLE
Revert "Enable Node Param for Rabbit Vhost"

### DIFF
--- a/tasks/vhost.yml
+++ b/tasks/vhost.yml
@@ -13,7 +13,8 @@
     user: '{{ item.user }}'
     password: '{{ item.password }}'
     vhost: '{{ item.vhost | default("/") }}'
-    node: '{{ item.node | default("rabbit") }}'
+    # Disabled due to ansible bug https://github.com/ansible/ansible-modules-extras/pull/2310
+    # node: '{{ item.node | default("rabbit") }}'
     tags: '{{ (item.tags | default("")) | join(",") }}'
     configure_priv: '{{ item.configure_priv | default(".*") }}'
     read_priv: '{{ item.read_priv | default(".*") }}'


### PR DESCRIPTION
This reverts commit b2f7480cb2f7bd558842985624b610701d88189d.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
