### PR TITLE
Specify Default Hostname

### DIFF
--- a/tasks/vhost.yml
+++ b/tasks/vhost.yml
@@ -3,7 +3,7 @@
 - name: Add RabbitMQ vhosts
   rabbitmq_vhost:
     name: '{{ item.name }}'
-    node: '{{ item.node | default("rabbit") }}'
+    node: 'rabbit@{{ ansible_hostname }}'
     state: present
     tracing: '{{ item.tracing | default("no") }}'
   with_items: '{{ rabbitmq_vhosts }}'
@@ -13,7 +13,7 @@
     user: '{{ item.user }}'
     password: '{{ item.password }}'
     vhost: '{{ item.vhost | default("/") }}'
-    node: '{{ item.node | default("rabbit") }}'
+    node: 'rabbit@{{ ansible_hostname }}'
     tags: '{{ (item.tags | default("")) | join(",") }}'
     configure_priv: '{{ item.configure_priv | default(".*") }}'
     read_priv: '{{ item.read_priv | default(".*") }}'


### PR DESCRIPTION
Travis CI seems to have a problem with not specifying node name
parameter.  Forcefully specify `ansible_hostname` as a node name.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
