### PR TITLE
Unify main.yml

### DIFF
--- a/.yamllint.conf
+++ b/.yamllint.conf
@@ -4,4 +4,4 @@ extends: default
 
 rules:
   line-length:
-    max: 120
+    max: 160

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,14 @@
 ---
 
-- include: packages.yml
+- include: packages_redhat.yml
+  when: ansible_os_family == 'RedHat'
+
+- include: packages_debian.yml
+  when: ansible_os_family == 'Debian'
+
 - include: configuration.yml
+
+- include: services.yml
 
 - meta: flush_handlers
 

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Start and enable RabbitMQ server
+  service:
+    enabled: True
+    name: 'rabbitmq-server'
+    state: started


### PR DESCRIPTION
Unify main.yml to a standard set of includes, with improved service
handling.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
