### PR TITLE
Fix rabbitmq-env.conf template

### DIFF
--- a/templates/rabbitmq-env.conf.j2
+++ b/templates/rabbitmq-env.conf.j2
@@ -1,3 +1,3 @@
 {% for variable,value in rabbitmq_conf_env.iteritems() %}
-{{ variable|upper() }}="{{ value }}"
+{{ variable|upper() }}={{ value }}
 {% endfor %}


### PR DESCRIPTION
In its current form, rabbitmq-env template prevents specifying at
least one particular env setting ciritical for RabbitMQ operation
under certain conditions:

    RABBITMQ_USE_LONGNAME=true

We need to get rid of those double quote so an arbitrary env value
could be specified. If needed, double quotes can be passed to the
rabbitmq-env vua the vars in the following way:

`
rabbitmq_conf_env:
    ENV_VARIABLE: '"value"'
`