### PR TITLE
Enables cluster setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ rabbitmq_conf_env:
 
 `rabbitmq_tcp_port` Listening port for the tcp interface
 
+`rabbitmq_cluster` A boolean variable, when set to true, the role adds all nodes in a play group to a cluster setup in a configuration file. It depends on a `ansible_play_hosts` magic variable, found in ansible 2.2 or later
+
+`rabbitmq_erlang_cookie` Only used when `rabbitmq_cluster` is used, to identify members of a cluster
+
 ### Plugins
 
 `rabbitmq_plugins` List of plugins to activate.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,5 @@ rabbitmq_users: []
 # rabbitmq TCP configuration
 rabbitmq_tcp_address: ''
 rabbitmq_tcp_port: 5672
+rabbitmq_cluster: False
+rabbitmq_erlang_cookie: 'THISISACOOKIEMONSTER'

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -18,3 +18,13 @@
     src: 'rabbitmq-env.conf.j2'
   notify: Restart RabbitMQ server
   when: rabbitmq_conf_env is defined
+
+- name: RabbitMQ set Erlang cookie
+  template:
+    dest: '/var/lib/rabbitmq/.erlang.cookie'
+    group: 'rabbitmq'
+    owner: 'rabbitmq'
+    mode: 0400
+    src: 'erlang.cookie.j2'
+  notify: Restart RabbitMQ server
+  when: rabbitmq_cluster and rabbitmq_erlang_cookie is defined

--- a/templates/erlang.cookie.j2
+++ b/templates/erlang.cookie.j2
@@ -1,0 +1,1 @@
+{{ rabbitmq_erlang_cookie }}

--- a/templates/rabbitmq.config.j2
+++ b/templates/rabbitmq.config.j2
@@ -5,5 +5,14 @@
 {% else %}
     {tcp_listeners, [{{ rabbitmq_tcp_port }}]}
 {% endif %}
+
+{% if rabbitmq_cluster %}
+      ,
+    {cluster_nodes, {[
+{% for host in ansible_play_hosts %}
+                      'rabbit@{{ hostvars[host]['ansible_hostname'] }}'{% if not loop.last %},{% endif %} 
+{% endfor %}
+                     ],disc}}
+{% endif %}
   ]}
 ].

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -10,6 +10,7 @@
       rabbitmq_plugins:
         - 'rabbitmq_management'
       rabbitmq_tcp_address: '0.0.0.0'
+      rabbitmq_cluster: False
       rabbitmq_vhosts:
         - name: 'test_vhost'
       rabbitmq_users:


### PR DESCRIPTION
This generates a cluster section in a rabbitmq.conf that
adds all the members of a current play into it, resulting
in nodes being added to a cluster automatically during bootsrap.
Adds following variables:

    rabbitmq_cluster - boolean, set to True to enable the cluster
    rabbitmq_erlang_cookie - string, unique Erlang cluster identifier

The proper generation of cluster section config depends on
'ansible_play_hosts' magic variable, that is found in ansible 2.2 or later.