### PR TITLE
Support overriding maximum open files setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ rabbitmq_users_definitions:
     - administrator
 ```
 
+## File descriptors
+
+`rabbitmq_fd_limit` Set it to a some value to override 1024 default (systemd supported)
 
 ## Testing
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,9 @@
   service:
     name: 'rabbitmq-server'
     state: restarted
+
+- name: Reloaad systemd services and restart RabbitMQ
+  systemd:
+    name: 'rabbitmq-server'
+    state: restarted
+    daemon_reload: yes

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -28,3 +28,13 @@
     src: 'erlang.cookie.j2'
   notify: Restart RabbitMQ server
   when: rabbitmq_cluster and rabbitmq_erlang_cookie is defined
+
+- name: Set up max file-descriptor limits in RabbitMQ systemd service
+  ini_file:
+    dest: /etc/systemd/system/rabbitmq-server.service.d/limits.conf
+    create: yes
+    section: Service
+    option: LimitNOFILE
+    value: '{{ rabbitmq_fd_limit }}'
+  notify: Reloaad systemd services and restart RabbitMQ
+  when: hostvars[inventory_hostname]['ansible_service_mgr'] == 'systemd' and rabbitmq_fd_limit is defined

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -11,6 +11,7 @@
         - 'rabbitmq_management'
       rabbitmq_tcp_address: '0.0.0.0'
       rabbitmq_cluster: False
+      rabbitmq_fd_limit: 2048
       rabbitmq_vhosts:
         - name: 'test_vhost'
       rabbitmq_users:


### PR DESCRIPTION
This adds a *rabbitmq_fd_limit* that overrides maximum open
file-descriptors value. Currently supporst only systemd.