### PR TITLE
Enable user removal & decouple it from vhost

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,7 @@
 
 - include: plugins.yml
 - include: vhost.yml
+- include: user.yml
 - include: policy.yml
 
 - include: sanitycheck.yml

--- a/tasks/user.yml
+++ b/tasks/user.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Manage RabbitMQ users and privileges
+  rabbitmq_user:
+    user: '{{ item.user }}'
+    password: '{{ item.password | default("") }}'
+    vhost: '{{ item.vhost | default("/") }}'
+    node: 'rabbit@{{ ansible_hostname }}'
+    tags: '{{ (item.tags | default("")) | join(",") }}'
+    configure_priv: '{{ item.configure_priv | default(".*") }}'
+    read_priv: '{{ item.read_priv | default(".*") }}'
+    write_priv: '{{ item.write_priv | default(".*") }}'
+    state: '{{ item.state | default("present") }}'
+    force: '{{ item.force | default("no") }}'
+  with_items: '{{ rabbitmq_users }}'

--- a/tasks/vhost.yml
+++ b/tasks/vhost.yml
@@ -4,20 +4,6 @@
   rabbitmq_vhost:
     name: '{{ item.name }}'
     node: 'rabbit@{{ ansible_hostname }}'
-    state: present
+    state: '{{ item.state | default("present") }}'
     tracing: '{{ item.tracing | default("no") }}'
   with_items: '{{ rabbitmq_vhosts }}'
-
-- name: Add RabbitMQ users and set privileges
-  rabbitmq_user:
-    user: '{{ item.user }}'
-    password: '{{ item.password }}'
-    vhost: '{{ item.vhost | default("/") }}'
-    node: 'rabbit@{{ ansible_hostname }}'
-    tags: '{{ (item.tags | default("")) | join(",") }}'
-    configure_priv: '{{ item.configure_priv | default(".*") }}'
-    read_priv: '{{ item.read_priv | default(".*") }}'
-    write_priv: '{{ item.write_priv | default(".*") }}'
-    state: present
-    force: '{{ item.force|default("no") }}'
-  with_items: '{{ rabbitmq_users }}'


### PR DESCRIPTION
- Provide way to remove users (remove default guest user for example)
- Provide way to remove vhost
- Move user handling to a separate task file
- Update the docs to reflect this
- Clarify cluster setup in the docs