### PR TITLE
Fix cluster setup @ Debian-based distros

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,12 +1,26 @@
 ---
 
-- name: Restart RabbitMQ server
-  service:
-    name: 'rabbitmq-server'
-    state: restarted
-
 - name: Reloaad systemd services and restart RabbitMQ
   systemd:
     name: 'rabbitmq-server'
     state: restarted
     daemon_reload: yes
+
+- name: Restart RabbitMQ server
+  service:
+    name: 'rabbitmq-server'
+    state: restarted
+
+- name: Force stop node so it can join the cluster
+  command: rabbitmqctl stop_app
+  when: rabbitmq_cluster
+  notify: Reset RabbitMQ cluster node
+
+- name: Reset RabbitMQ cluster node
+  command: rabbitmqctl reset
+  when: rabbitmq_cluster
+  notify: Start RabbitMQ cluster node
+
+- name: Start RabbitMQ cluster node
+  command: rabbitmqctl start_app
+  when: rabbitmq_cluster

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -7,7 +7,9 @@
     mode: 0644
     owner: 'rabbitmq'
     src: 'rabbitmq.config.j2'
-  notify: Restart RabbitMQ server
+  notify:
+    - Restart RabbitMQ server
+    - Force stop node so it can join the cluster
 
 - name: RabbitMQ Environment-specific configuration
   template:
@@ -16,7 +18,9 @@
     mode: 0644
     owner: 'rabbitmq'
     src: 'rabbitmq-env.conf.j2'
-  notify: Restart RabbitMQ server
+  notify:
+    - Restart RabbitMQ server
+    - Force stop node so it can join the cluster
   when: rabbitmq_conf_env is defined
 
 - name: RabbitMQ set Erlang cookie
@@ -26,7 +30,9 @@
     owner: 'rabbitmq'
     mode: 0400
     src: 'erlang.cookie.j2'
-  notify: Restart RabbitMQ server
+  notify:
+    - Restart RabbitMQ server
+    - Force stop node so it can join the cluster
   when: rabbitmq_cluster and rabbitmq_erlang_cookie is defined
 
 - name: Set up max file-descriptor limits in RabbitMQ systemd service
@@ -38,3 +44,5 @@
     value: '{{ rabbitmq_fd_limit }}'
   notify: Reloaad systemd services and restart RabbitMQ
   when: hostvars[inventory_hostname]['ansible_service_mgr'] == 'systemd' and rabbitmq_fd_limit is defined
+
+- meta: flush_handlers

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,11 +7,6 @@
   when: ansible_os_family == 'Debian'
 
 - include_tasks: configuration.yml
-
-- include_tasks: services.yml
-
-- meta: flush_handlers
-
 - include_tasks: plugins.yml
 - include_tasks: vhost.yml
 - include_tasks: user.yml

--- a/tasks/packages_debian.yml
+++ b/tasks/packages_debian.yml
@@ -3,8 +3,8 @@
 - name: Install package dependencies
   apt:
     name:
-     - software-properties-common
-     - ubuntu-cloud-keyring
+      - software-properties-common
+      - ubuntu-cloud-keyring
     state: latest
     update_cache: yes
   when: rabbitmq_use_repo

--- a/tasks/packages_debian.yml
+++ b/tasks/packages_debian.yml
@@ -1,8 +1,10 @@
 ---
 
-- name: Install software-properties-common
+- name: Install package dependencies
   apt:
-    name: software-properties-common
+    name:
+     - software-properties-common
+     - ubuntu-cloud-keyring
     state: latest
     update_cache: yes
   when: rabbitmq_use_repo
@@ -18,4 +20,3 @@
     name: 'rabbitmq-server'
     state: latest
     update_cache: yes
-  notify: Reloaad systemd services and restart RabbitMQ

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -1,7 +1,0 @@
----
-
-- name: Start and enable RabbitMQ server
-  service:
-    enabled: True
-    name: 'rabbitmq-server'
-    state: started


### PR DESCRIPTION
#21 fix

- Added a 3-step handler that will force node to join cluster if any config
  is changed (rabbit.conf or rabbitmq-env.conf or Erlang cookie)
- Forced install of ubuntu-cloud-keyring when repository is used
- Removed service restart handler on Debian-based distros, RabbitMQ package
  trigger scripts will take care of that anyway