### PR TITLE
Maintain the order of the `ansible_play_hosts`

### DIFF
--- a/templates/rabbitmq.config.j2
+++ b/templates/rabbitmq.config.j2
@@ -9,7 +9,7 @@
 {% if rabbitmq_cluster %}
       ,
     {cluster_nodes, {[
-{% for host in ansible_play_hosts %}
+{% for host in ansible_play_hosts|sort(reverse=True) %}
                       'rabbit@{{ hostvars[host]['ansible_hostname'] }}'{% if not loop.last %},{% endif %} 
 {% endfor %}
                      ],disc}}


### PR DESCRIPTION
The order of the ansible_play_hosts is not fixed so everytime
it changes the order of the hosts in rabbitmq.config which triggers
rabbitmq service restart. If there are no changes we should avoid
triggering the restart.

This PR fixes the order of the ansible_play_hosts to be sorted in
reverse order so that it will be maintained for every run.

NOTE: These is no motivation behind using `reverse` order. We can use
any type of order to maintain the hosts order for every run.