### PR TITLE
Replace methods that don't work with Python3

### DIFF
--- a/templates/rabbitmq-env.conf.j2
+++ b/templates/rabbitmq-env.conf.j2
@@ -1,3 +1,3 @@
-{% for variable,value in rabbitmq_conf_env.iteritems() %}
+{% for variable,value in rabbitmq_conf_env.items() %}
 {{ variable|upper() }}={{ value }}
 {% endfor %}


### PR DESCRIPTION
Since `iteritems()` doesn't work with Python3, replace it with `items()` that works with both Python2 and Python3 Ansible.